### PR TITLE
Rotation transformation updates for >= iOS8 and enabled split view

### DIFF
--- a/Classes/OBDragDropManager.m
+++ b/Classes/OBDragDropManager.m
@@ -60,8 +60,7 @@
 @end
 
 
-#define OBDRAGDROPMANAGER_IS_IOS7_OR_EARLIER ([[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] != NSOrderedAscending)
-
+#define OBDRAGDROPMANAGER_IS_IOS7_OR_EARLIER (NSFoundationVersionNumber < NSFoundationVersionNumber_iOS_8_0)
 
 @implementation OBDragDropManager
 
@@ -148,6 +147,8 @@
   self.overlayWindow.userInteractionEnabled = NO;
   if (OBDRAGDROPMANAGER_IS_IOS7_OR_EARLIER)
     self.overlayWindow.transform = [self transformForOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
+  else
+    self.overlayWindow.rootViewController = [UIViewController new];
 }
 
 

--- a/OBDragDropTest/Launch Screen.storyboard
+++ b/OBDragDropTest/Launch Screen.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2016 Oblong Industries. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="20" y="559" width="560" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OBDragDropTest" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="20" y="180" width="560" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="601" y="526"/>
+        </scene>
+    </scenes>
+</document>

--- a/OBDragDropTest/OBDragDropTest.xcodeproj/project.pbxproj
+++ b/OBDragDropTest/OBDragDropTest.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3968602615B864B0009C3D7B /* UIView+OBDropZone.m in Sources */ = {isa = PBXBuildFile; fileRef = 3968602315B864B0009C3D7B /* UIView+OBDropZone.m */; };
 		397E048716DB7C1E00DC9715 /* AdditionalSourcesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 397E048616DB7C1E00DC9715 /* AdditionalSourcesViewController.m */; };
 		39B6F7DD1AAF7AE5002B8B41 /* SourceTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 39B6F7DC1AAF7AE5002B8B41 /* SourceTableViewController.m */; };
+		BDF855EF1C63C1A900B55B29 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BDF855EE1C63C1A900B55B29 /* Launch Screen.storyboard */; };
 		F302486C17AC224D00346CE9 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F302486B17AC224D00346CE9 /* Default-568h@2x.png */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +53,7 @@
 		39B6F7DB1AAF7AE5002B8B41 /* SourceTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceTableViewController.h; sourceTree = "<group>"; };
 		39B6F7DC1AAF7AE5002B8B41 /* SourceTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SourceTableViewController.m; sourceTree = "<group>"; };
 		39F0AAC316C8FB3B008B6482 /* OBDragDrop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OBDragDrop.h; path = ../../Classes/OBDragDrop.h; sourceTree = "<group>"; };
+		BDF855EE1C63C1A900B55B29 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		F302486B17AC224D00346CE9 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -73,6 +75,7 @@
 		390E610D14F6CB8100F8FA74 = {
 			isa = PBXGroup;
 			children = (
+				BDF855EE1C63C1A900B55B29 /* Launch Screen.storyboard */,
 				F302486B17AC224D00346CE9 /* Default-568h@2x.png */,
 				390E612214F6CB8100F8FA74 /* OBDragDropTest */,
 				390E611B14F6CB8100F8FA74 /* Frameworks */,
@@ -195,6 +198,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDF855EF1C63C1A900B55B29 /* Launch Screen.storyboard in Resources */,
 				390E612714F6CB8100F8FA74 /* InfoPlist.strings in Resources */,
 				F302486C17AC224D00346CE9 /* Default-568h@2x.png in Resources */,
 			);

--- a/OBDragDropTest/OBDragDropTest/OBDragDropTest-Info.plist
+++ b/OBDragDropTest/OBDragDropTest/OBDragDropTest-Info.plist
@@ -26,10 +26,14 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
- Created Launch Screen storyboard to enable split view
- Fixed iOS7 check
- >= iOS8 we have a rootViewController instead of caring about transforming the UIWindow.