### PR TITLE
- Replace UIWindow with a custom HideableWindow that instead of just

### DIFF
--- a/Classes/HideableWindow.h
+++ b/Classes/HideableWindow.h
@@ -1,0 +1,13 @@
+//
+//  HideableWindow.h
+//  Mezzanine
+//
+//  Created by miguel on 6/12/16.
+//  Copyright © 2016 Oblong Industries. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface HideableWindow : UIWindow
+
+@end

--- a/Classes/HideableWindow.m
+++ b/Classes/HideableWindow.m
@@ -1,0 +1,47 @@
+//
+//  HideableWindow.m
+//  Mezzanine
+//
+//  Created by miguel on 6/12/16.
+//  Copyright © 2016 Oblong Industries. All rights reserved.
+//
+
+#import "HideableWindow.h"
+
+@interface HideableWindow ()
+
+@property (nonatomic, strong) UIViewController *hiddenRootViewController;
+
+@end
+
+@implementation HideableWindow
+
+// Check out http://petersteinberger.com/blog/2015/rotation-multiple-windows-bug/ or http://openradar.appspot.com/17265615
+- (void)setHidden:(BOOL)hidden
+{
+  [super setHidden:hidden];
+
+  // Since iOS 8 adding more UIWindow breaks rotation logic
+  // Instead of use real hiding, the root view controller needs to be removed.
+  if (hidden)
+  {
+    self.hiddenRootViewController = self.rootViewController;
+    [super setRootViewController:nil];
+  }
+  else
+  {
+    if (self.hiddenRootViewController)
+    {
+      [super setRootViewController:self.hiddenRootViewController];
+      self.hiddenRootViewController = nil;
+    }
+  }
+}
+
+- (void)setRootViewController:(UIViewController *)rootViewController
+{
+  [super setRootViewController:rootViewController];
+  self.hiddenRootViewController = nil;
+}
+
+@end

--- a/Classes/OBDragDropManager.m
+++ b/Classes/OBDragDropManager.m
@@ -10,7 +10,7 @@
 #import "UIView+OBDropZone.h"
 #import "UIGestureRecognizer+OBDragDrop.h"
 #import "OBLongPressDragDropGestureRecognizer.h"
-
+#import "HideableWindow.h"
 
 @implementation OBOvum
 
@@ -141,7 +141,7 @@
     self.overlayWindow = nil;
   }
 
-  self.overlayWindow = [[UIWindow alloc] initWithFrame:mainWindow.frame];
+  self.overlayWindow = [[HideableWindow alloc] initWithFrame:mainWindow.frame];
   self.overlayWindow.windowLevel = UIWindowLevelAlert;
   self.overlayWindow.hidden = YES;
   self.overlayWindow.userInteractionEnabled = NO;


### PR DESCRIPTION
hiding removes and resets its rootViewController.
This prevents orientation issues due to the secondary window.